### PR TITLE
add retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data-raw*
 inst/doc*
 hoopR.Rcheck*
 nba_pbp_db
+mbb_pbp_db

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,15 @@
+# **hoopR 1.0.4**
+### **Add retry**
+- Adding [```httr::retry()```](https://httr.r-lib.org/reference/RETRY.html) to all function calls to more naturally navigate rejected/failed requests from the API.
+
 # **hoopR 1.0.2-3** 
+### **Quick fix for update db functions**
 
-### Quick fix for update db functions
-
-# **hoopR 1.0.1**
-
+# **hoopR 1.0.1-4**
 ### **Dependency pruning**
 This update is a non-user facing change to package dependencies to shrink the list of dependencies.
 
 # **hoopR 1.0.0**
-
 ### **Package renamed to hoopR**
 To reflect that the package is no longer just a men's college basketball and KenPom package, but also an NBA package. 
 
@@ -23,7 +24,6 @@ To reflect that the package is no longer just a men's college basketball and Ken
 - [```hoopR::load_nba_pbp()```](https://saiemgilani.github.io/hoopR/reference/load_nba_pbp.html) and [```hoopR::update_nba_db()```](https://saiemgilani.github.io/hoopR/reference/update_nba_db.html) functions added
 
 # **hoopR 0.4**
-
 - Added support for ESPN's NBA play-by-play endpoints with the addition of the following functions:
 - ```hoopR::espn_nba_game_all()``` - a convenience wrapper function around the following three functions (returns the results as a list of three data frames)
 - ```hoopR::espn_nba_team_box()```
@@ -33,8 +33,7 @@ To reflect that the package is no longer just a men's college basketball and Ken
 - ```hoopR::espn_nba_scoreboard()``` 
 
 # **hoopR 0.3.0**
-
-## Dependencies
+### **Dependencies**
 - ```R``` version 3.5.0 or greater dependency added
 - ```purrr``` version 0.3.0 or greater dependency added
 - ```rvest``` version 1.0.0 or greater dependency added
@@ -47,21 +46,16 @@ To reflect that the package is no longer just a men's college basketball and Ken
 - ```furrr``` dependency added
 - ```future``` dependency added
 
-## **Test coverage**
-
+### **Test coverage**
 * Added tests for all KP and ESPN functions
 
 #### **Function Naming Convention Change**
-
 * All functions sourced from [kenpom.com](https://www.kenpom.com/) will start with `kp_` as opposed to `get_` 
-
 * Similarly, data and metrics sourced from ESPN will begin with `espn_` as opposed to `cbb_`. Moreover, all references to `cbb_` have been changed to `mbb_` as appropriate.
-
 * Data sourced directly from the NCAA website will start the function with `ncaa_`
 
 
 # **hoopR 0.2.0-3**
-
 - Added support for ESPN's men's college basketball play-by-play endpoints with the addition of the following functions:
 - ```hoopR::espn_mbb_game_all()``` - a convenience wrapper function around the following three functions (returns the results as a list of three data frames)
 - ```hoopR::espn_mbb_team_box()```
@@ -74,11 +68,9 @@ To reflect that the package is no longer just a men's college basketball and Ken
 - ```hoopR::espn_mbb_rankings()``` (bumps to v0.2.3)
 
 # **hoopR 0.1.0** 
-
 -    Minor fixes
 
 # **hoopR 0.0.0.9**
-
 Initial Commits, remaining tasks:
 
 -   Game Prep Tables

--- a/R/espn_mbb_data.R
+++ b/R/espn_mbb_data.R
@@ -23,66 +23,113 @@ espn_mbb_game_all <- function(game_id){
   ## game_id
   full_url <- paste0(play_base_url,
                      "gameId=", game_id)
-  raw_play_df <- jsonlite::fromJSON(full_url)[["gamepackageJSON"]]
-  raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
 
-  #---- Play-by-Play ------
-  plays <- raw_play_df[["plays"]] %>%
-    tidyr::unnest_wider(unlist(.data$participants))
-  suppressWarnings(
-    aths <- plays %>%
-      dplyr::group_by(.data$id) %>%
-      dplyr::select(.data$id, .data$athlete.id) %>%
-      tidyr::unnest_wider(unlist(.data$athlete.id, use.names=FALSE),names_sep = "_")
+
+  res <- httr::RETRY("GET", full_url)
+
+  # Check the result
+  check_status(res)
+
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
+      raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
+
+      #---- Play-by-Play ------
+      plays <- raw_play_df[["plays"]] %>%
+        tidyr::unnest_wider(unlist(.data$participants))
+      suppressWarnings(
+        aths <- plays %>%
+          dplyr::group_by(.data$id) %>%
+          dplyr::select(.data$id, .data$athlete.id) %>%
+          tidyr::unnest_wider(unlist(.data$athlete.id, use.names=FALSE),names_sep = "_")
+      )
+      names(aths)<-c("play.id","athlete1.id","athlete2.id")
+      plays_df <- dplyr::bind_cols(plays, aths) %>%
+        select(-.data$athlete.id)
+
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no play-by-play data for {game_id} available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
+    }
   )
-  names(aths)<-c("play.id","athlete1.id","athlete2.id")
-  plays_df <- dplyr::bind_cols(plays, aths) %>%
-    select(-.data$athlete.id)
   #---- Team Box ------
-  teams_box_score_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["teams"]]),flatten=TRUE)
-  teams_box_score_df_2 <- teams_box_score_df[[1]][[2]] %>%
-    dplyr::select(.data$displayValue, .data$label) %>%
-    dplyr::rename(Home = .data$displayValue)
-  teams_box_score_df_1 <- teams_box_score_df[[1]][[1]] %>%
-    dplyr::select(.data$displayValue) %>%
-    dplyr::rename(Away = .data$displayValue)
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
 
-  team_box_score = dplyr::bind_cols(teams_box_score_df_2, teams_box_score_df_1)
-  tm <- c(teams_box_score_df[2,"team.shortDisplayName"], "Team", teams_box_score_df[1,"team.shortDisplayName"])
-  names(tm) <- c("Home","label","Away")
-  team_box_score = dplyr::bind_rows(tm, team_box_score)
+      teams_box_score_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["teams"]]),flatten=TRUE)
+      teams_box_score_df_2 <- teams_box_score_df[[1]][[2]] %>%
+        dplyr::select(.data$displayValue, .data$label) %>%
+        dplyr::rename(Home = .data$displayValue)
+      teams_box_score_df_1 <- teams_box_score_df[[1]][[1]] %>%
+        dplyr::select(.data$displayValue) %>%
+        dplyr::rename(Away = .data$displayValue)
+
+      team_box_score = dplyr::bind_cols(teams_box_score_df_2, teams_box_score_df_1)
+      tm <- c(teams_box_score_df[2,"team.shortDisplayName"], "Team", teams_box_score_df[1,"team.shortDisplayName"])
+      names(tm) <- c("Home","label","Away")
+      team_box_score = dplyr::bind_rows(tm, team_box_score)
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no team box score data for {game_id} available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
+    }
+  )
   #---- Player Box ------
-  players_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["players"]]), flatten=TRUE) %>%
-    tidyr::unnest(.data$statistics) %>%
-    tidyr::unnest(.data$athletes)
-  stat_cols <- players_df$names[[1]]
-  stats <- players_df$stats
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
+      players_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["players"]]), flatten=TRUE) %>%
+        tidyr::unnest(.data$statistics) %>%
+        tidyr::unnest(.data$athletes)
+      stat_cols <- players_df$names[[1]]
+      stats <- players_df$stats
 
-  stats_df <- as.data.frame(do.call(rbind,stats))
-  colnames(stats_df) <- stat_cols
+      stats_df <- as.data.frame(do.call(rbind,stats))
+      colnames(stats_df) <- stat_cols
 
-  players_df <- players_df %>%
-    dplyr::filter(!.data$didNotPlay) %>%
-    dplyr::select(.data$starter,.data$ejected, .data$didNotPlay,.data$active,
-                  .data$athlete.displayName,.data$athlete.jersey,
-                  .data$athlete.id,.data$athlete.shortName,
-                  .data$athlete.headshot.href,.data$athlete.position.name,
-                  .data$athlete.position.abbreviation,.data$team.shortDisplayName,
-                  .data$team.name,.data$team.logo,.data$team.id,.data$team.abbreviation,
-                  .data$team.color,.data$team.alternateColor
-    )
+      players_df <- players_df %>%
+        dplyr::filter(!.data$didNotPlay) %>%
+        dplyr::select(.data$starter,.data$ejected, .data$didNotPlay,.data$active,
+                      .data$athlete.displayName,.data$athlete.jersey,
+                      .data$athlete.id,.data$athlete.shortName,
+                      .data$athlete.headshot.href,.data$athlete.position.name,
+                      .data$athlete.position.abbreviation,.data$team.shortDisplayName,
+                      .data$team.name,.data$team.logo,.data$team.id,.data$team.abbreviation,
+                      .data$team.color,.data$team.alternateColor
+        )
 
-  player_box <- dplyr::bind_cols(stats_df,players_df) %>%
-    dplyr::select(.data$athlete.displayName,.data$team.shortDisplayName, tidyr::everything())
-  plays_df <- plays_df %>%
-    janitor::clean_names()
-  team_box_score <- team_box_score %>%
-    janitor::clean_names()
-  player_box <- player_box %>%
-    janitor::clean_names() %>%
-    dplyr::rename(
-      fg3 = .data$x3pt
-    )
+      player_box <- dplyr::bind_cols(stats_df,players_df) %>%
+        dplyr::select(.data$athlete.displayName,.data$team.shortDisplayName, tidyr::everything())
+      plays_df <- plays_df %>%
+        janitor::clean_names()
+      team_box_score <- team_box_score %>%
+        janitor::clean_names()
+      player_box <- player_box %>%
+        janitor::clean_names() %>%
+        dplyr::rename(
+          fg3 = .data$x3pt
+        )
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no player box score data for {game_id} available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
+    }
+  )
   pbp <- c(list(plays_df), list(team_box_score),list(player_box))
   names(pbp) <- c("Plays","Team","Player")
   return(pbp)
@@ -112,22 +159,42 @@ espn_mbb_pbp <- function(game_id){
   ## game_id
   full_url <- paste0(play_base_url,
                      "gameId=", game_id)
-  raw_play_df <- jsonlite::fromJSON(full_url)[["gamepackageJSON"]]
-  raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
-  #---- Play-by-Play ------
-  plays <- raw_play_df[["plays"]] %>%
-    tidyr::unnest_wider(unlist(.data$participants))
-  suppressWarnings(
-    aths <- plays %>%
-      dplyr::group_by(.data$id) %>%
-      dplyr::select(.data$id, .data$athlete.id) %>%
-      tidyr::unnest_wider(unlist(.data$athlete.id, use.names=FALSE),names_sep = "_")
+
+  res <- httr::RETRY("GET", full_url)
+
+  # Check the result
+  check_status(res)
+
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
+      raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
+
+      #---- Play-by-Play ------
+      plays <- raw_play_df[["plays"]] %>%
+        tidyr::unnest_wider(unlist(.data$participants))
+      suppressWarnings(
+        aths <- plays %>%
+          dplyr::group_by(.data$id) %>%
+          dplyr::select(.data$id, .data$athlete.id) %>%
+          tidyr::unnest_wider(unlist(.data$athlete.id, use.names=FALSE),names_sep = "_")
+      )
+      names(aths)<-c("play.id","athlete1.id","athlete2.id")
+      plays_df <- dplyr::bind_cols(plays, aths) %>%
+        select(-.data$athlete.id)
+      plays_df <- plays_df %>%
+        janitor::clean_names()
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no play-by-play data for {game_id} available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
+    }
   )
-  names(aths)<-c("play.id","athlete1.id","athlete2.id")
-  plays_df <- dplyr::bind_cols(plays, aths) %>%
-    select(-.data$athlete.id)
-  plays_df <- plays_df %>%
-    janitor::clean_names()
 
   return(plays_df)
 }
@@ -154,23 +221,44 @@ espn_mbb_team_box <- function(game_id){
   ## game_id
   full_url <- paste0(play_base_url,
                      "gameId=", game_id)
-  raw_play_df <- jsonlite::fromJSON(full_url)[["gamepackageJSON"]]
-  raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
-  #---- Team Box ------
-  teams_box_score_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["teams"]]),flatten=TRUE)
-  teams_box_score_df_2 <- teams_box_score_df[[1]][[2]] %>%
-    dplyr::select(.data$displayValue, .data$label) %>%
-    dplyr::rename(Home = .data$displayValue)
-  teams_box_score_df_1 <- teams_box_score_df[[1]][[1]] %>%
-    dplyr::select(.data$displayValue) %>%
-    dplyr::rename(Away = .data$displayValue)
 
-  team_box_score = dplyr::bind_cols(teams_box_score_df_2, teams_box_score_df_1)
-  tm <- c(teams_box_score_df[2,"team.shortDisplayName"], "Team", teams_box_score_df[1,"team.shortDisplayName"])
-  names(tm) <- c("Home","label","Away")
-  team_box_score = dplyr::bind_rows(tm, team_box_score)
-  team_box_score <- team_box_score %>%
-    janitor::clean_names()
+  res <- httr::RETRY("GET", full_url)
+
+  # Check the result
+  check_status(res)
+
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+
+  #---- Team Box ------
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
+      raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
+      #---- Team Box ------
+      teams_box_score_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["teams"]]),flatten=TRUE)
+      teams_box_score_df_2 <- teams_box_score_df[[1]][[2]] %>%
+        dplyr::select(.data$displayValue, .data$label) %>%
+        dplyr::rename(Home = .data$displayValue)
+      teams_box_score_df_1 <- teams_box_score_df[[1]][[1]] %>%
+        dplyr::select(.data$displayValue) %>%
+        dplyr::rename(Away = .data$displayValue)
+
+      team_box_score = dplyr::bind_cols(teams_box_score_df_2, teams_box_score_df_1)
+      tm <- c(teams_box_score_df[2,"team.shortDisplayName"], "Team", teams_box_score_df[1,"team.shortDisplayName"])
+      names(tm) <- c("Home","label","Away")
+      team_box_score = dplyr::bind_rows(tm, team_box_score)
+      team_box_score <- team_box_score %>%
+        janitor::clean_names()
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no team box score data for {game_id} available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
+    }
+  )
   return(team_box_score)
 }
 #' Get ESPN men's college basketball player box scores
@@ -196,39 +284,61 @@ espn_mbb_player_box <- function(game_id){
   ## game_id
   full_url <- paste0(play_base_url,
                      "gameId=", game_id)
-  raw_play_df <- jsonlite::fromJSON(full_url)[["gamepackageJSON"]]
-  raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
+
+  res <- httr::RETRY("GET", full_url)
+
+  # Check the result
+  check_status(res)
+
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+
   #---- Player Box ------
-  players_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["players"]]), flatten=TRUE) %>%
-    tidyr::unnest(.data$statistics) %>%
-    tidyr::unnest(.data$athletes)
-  stat_cols <- players_df$names[[1]]
-  stats <- players_df$stats
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
+      raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
+      #---- Player Box ------
+      players_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["players"]]), flatten=TRUE) %>%
+        tidyr::unnest(.data$statistics) %>%
+        tidyr::unnest(.data$athletes)
+      stat_cols <- players_df$names[[1]]
+      stats <- players_df$stats
 
-  stats_df <- as.data.frame(do.call(rbind,stats))
-  colnames(stats_df) <- stat_cols
+      stats_df <- as.data.frame(do.call(rbind,stats))
+      colnames(stats_df) <- stat_cols
 
-  players_df <- players_df %>%
-    dplyr::filter(!.data$didNotPlay) %>%
-    dplyr::select(.data$starter,.data$ejected, .data$didNotPlay,.data$active,
-                  .data$athlete.displayName,.data$athlete.jersey,
-                  .data$athlete.id,.data$athlete.shortName,
-                  .data$athlete.headshot.href,.data$athlete.position.name,
-                  .data$athlete.position.abbreviation,.data$team.shortDisplayName,
-                  .data$team.name,.data$team.logo,.data$team.id,.data$team.abbreviation,
-                  .data$team.color,.data$team.alternateColor
-    )
+      players_df <- players_df %>%
+        dplyr::filter(!.data$didNotPlay) %>%
+        dplyr::select(.data$starter,.data$ejected, .data$didNotPlay,.data$active,
+                      .data$athlete.displayName,.data$athlete.jersey,
+                      .data$athlete.id,.data$athlete.shortName,
+                      .data$athlete.headshot.href,.data$athlete.position.name,
+                      .data$athlete.position.abbreviation,.data$team.shortDisplayName,
+                      .data$team.name,.data$team.logo,.data$team.id,.data$team.abbreviation,
+                      .data$team.color,.data$team.alternateColor
+        )
 
-  player_box <- dplyr::bind_cols(stats_df,players_df) %>%
-    dplyr::select(.data$athlete.displayName,.data$team.shortDisplayName, tidyr::everything())
+      player_box <- dplyr::bind_cols(stats_df,players_df) %>%
+        dplyr::select(.data$athlete.displayName,.data$team.shortDisplayName, tidyr::everything())
 
-  player_box <- player_box %>%
-    janitor::clean_names() %>%
-    dplyr::rename(
-      fg3 = .data$x3pt
-    )
+      player_box <- player_box %>%
+        janitor::clean_names() %>%
+        dplyr::rename(
+          fg3 = .data$x3pt
+        )
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no player box score data for {game_id} available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
+    }
+  )
   return(player_box)
 }
+
 
 
 #' Get ESPN conference names and ids
@@ -249,13 +359,29 @@ espn_mbb_conferences <- function(){
   options(scipen = 999)
   play_base_url <- "http://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/scoreboard/conferences"
 
-  ## Inputs
-  ## game_id
+  res <- httr::RETRY("GET", play_base_url)
 
-  conferences <- jsonlite::fromJSON(play_base_url)[["conferences"]] %>%
-    dplyr::select(-.data$subGroups) %>%
-    janitor::clean_names()
+  # Check the result
+  check_status(res)
 
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+
+  tryCatch(
+    expr = {
+      conferences <- jsonlite::fromJSON(resp)[["conferences"]] %>%
+        dplyr::select(-.data$subGroups) %>%
+        janitor::clean_names()
+
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no conferences info available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
+    }
+  )
   return(conferences)
 }
 
@@ -275,53 +401,71 @@ espn_mbb_teams <- function(){
   options(scipen = 999)
   play_base_url <- "http://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/teams?groups=50&limit=1000"
 
-  ## Inputs
-  ## game_id
-  leagues <- jsonlite::fromJSON(play_base_url)[["sports"]][["leagues"]][[1]][['teams']][[1]][['team']] %>%
-    dplyr::group_by(.data$id) %>%
-    tidyr::unnest_wider(unlist(.data$logos, use.names=FALSE),names_sep = "_") %>%
-    tidyr::unnest_wider(.data$logos_href,names_sep = "_") %>%
-    dplyr::select(-.data$logos_width,-.data$logos_height,
-                  -.data$logos_alt, -.data$logos_rel) %>%
-    dplyr::ungroup()
+  res <- httr::RETRY("GET", play_base_url)
 
-  records <- leagues$record
-  records<- records %>% tidyr::unnest_wider(.data$items) %>%
-    tidyr::unnest_wider(.data$stats,names_sep = "_") %>%
-    dplyr::mutate(row = dplyr::row_number())
-  stat <- records %>%
-    dplyr::group_by(.data$row) %>%
-    purrr::map_if(is.data.frame, list)
-  stat <- lapply(stat$stats_1,function(x) x %>%
-                      purrr::map_if(is.data.frame,list) %>%
-                      dplyr::as_tibble() )
+  # Check the result
+  check_status(res)
 
-  s <- lapply(stat, function(x) {
-    tidyr::pivot_wider(x)
-  })
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
 
-  s <- tibble::tibble(g = s)
-  stats <- s %>% unnest_wider(.data$g)
+  tryCatch(
+    expr = {
 
-  records <- dplyr::bind_cols(records %>% dplyr::select(.data$summary), stats)
-  leagues <- leagues %>% dplyr::select(
-    -.data$record,
-    -.data$links,
-    -.data$isActive,
-    -.data$isAllStar,
-    -.data$uid,
-    -.data$slug)
-  teams <- leagues %>%
-    dplyr::rename(
-      logo = .data$logos_href_1,
-      logo_dark = .data$logos_href_2,
-      mascot = .data$name,
-      team = .data$location,
-      team_id = .data$id,
-      short_name = .data$shortDisplayName,
-      alternate_color = .data$alternateColor,
-      display_name = .data$displayName
-    )
+      leagues <- jsonlite::fromJSON(resp)[["sports"]][["leagues"]][[1]][['teams']][[1]][['team']] %>%
+        dplyr::group_by(.data$id) %>%
+        tidyr::unnest_wider(unlist(.data$logos, use.names=FALSE),names_sep = "_") %>%
+        tidyr::unnest_wider(.data$logos_href,names_sep = "_") %>%
+        dplyr::select(-.data$logos_width,-.data$logos_height,
+                      -.data$logos_alt, -.data$logos_rel) %>%
+        dplyr::ungroup()
+
+      records <- leagues$record
+      records<- records %>% tidyr::unnest_wider(.data$items) %>%
+        tidyr::unnest_wider(.data$stats,names_sep = "_") %>%
+        dplyr::mutate(row = dplyr::row_number())
+      stat <- records %>%
+        dplyr::group_by(.data$row) %>%
+        purrr::map_if(is.data.frame, list)
+      stat <- lapply(stat$stats_1,function(x) x %>%
+                       purrr::map_if(is.data.frame,list) %>%
+                       dplyr::as_tibble())
+
+      s <- lapply(stat, function(x) {
+        tidyr::pivot_wider(x)
+      })
+
+      s <- tibble::tibble(g = s)
+      stats <- s %>% unnest_wider(.data$g)
+
+      records <- dplyr::bind_cols(records %>% dplyr::select(.data$summary), stats)
+      leagues <- leagues %>% dplyr::select(
+        -.data$record,
+        -.data$links,
+        -.data$isActive,
+        -.data$isAllStar,
+        -.data$uid,
+        -.data$slug)
+      teams <- leagues %>%
+        dplyr::rename(
+          logo = .data$logos_href_1,
+          logo_dark = .data$logos_href_2,
+          mascot = .data$name,
+          team = .data$location,
+          team_id = .data$id,
+          short_name = .data$shortDisplayName,
+          alternate_color = .data$alternateColor,
+          display_name = .data$displayName
+        )
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no teams data available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
+    }
+  )
   return(teams)
 }
 
@@ -361,102 +505,118 @@ espn_mbb_scoreboard <- function(season){
 
   schedule_api <- glue::glue("http://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/scoreboard?groups=50&limit=1000&dates={season_dates}")
 
-  raw_sched <- jsonlite::fromJSON(schedule_api, simplifyDataFrame = FALSE, simplifyVector = FALSE, simplifyMatrix = FALSE)
+  res <- httr::RETRY("GET", schedule_api)
 
-  cbb_data <- raw_sched[["events"]] %>%
-    tibble::tibble(data = .data$.) %>%
-    tidyr::unnest_wider(.data$data) %>%
-    tidyr::unchop(.data$competitions) %>%
-    dplyr::select(-.data$id, -.data$uid, -.data$date, -.data$status) %>%
-    tidyr::unnest_wider(.data$competitions) %>%
-    dplyr::rename(matchup = .data$name, matchup_short = .data$shortName, game_id = .data$id, game_uid = .data$uid, game_date = .data$date) %>%
-    tidyr::hoist(.data$status,
-                 status_name = list("type", "name")) %>%
-    dplyr::select(!dplyr::any_of(c("timeValid", "neutralSite", "conferenceCompetition","recent", "venue", "type"))) %>%
-    tidyr::unnest_wider(.data$season) %>%
-    dplyr::rename(season = .data$year) %>%
-    dplyr::select(-dplyr::any_of("status")) %>%
-    tidyr::hoist(
-      .data$competitors,
-      home_team_name = list(1, "team", "name"),
-      home_team_logo = list(1, "team", "logo"),
-      home_team_abb = list(1, "team", "abbreviation"),
-      home_team_id = list(1, "team", "id"),
-      home_team_location = list(1, "team", "location"),
-      home_team_full = list(1, "team", "displayName"),
-      home_team_color = list(1, "team", "color"),
-      home_score = list(1, "score"),
-      home_win = list(1, "winner"),
-      home_record = list(1, "records", 1, "summary"),
-      # away team
-      away_team_name = list(2, "team", "name"),
-      away_team_logo = list(2, "team", "logo"),
-      away_team_abb = list(2, "team", "abbreviation"),
-      away_team_id = list(2, "team", "id"),
-      away_team_location = list(2, "team", "location"),
-      away_team_full = list(2, "team", "displayName"),
-      away_team_color = list(2, "team", "color"),
-      away_score = list(2, "score"),
-      away_win = list(2, "winner"),
-      away_record = list(2, "records", 1, "summary"),
-    ) %>%
-    dplyr::mutate(home_win = as.integer(.data$home_win),
-                  away_win = as.integer(.data$away_win),
-                  home_score = as.integer(.data$home_score),
-                  away_score = as.integer(.data$away_score))
+  # Check the result
+  check_status(res)
 
-  if("leaders" %in% names(cbb_data)){
-    schedule_out <- cbb_data %>%
-      tidyr::hoist(
-        .data$leaders,
-        # points
-        points_leader_points = list(1, "leaders", 1, "value"),
-        points_leader_stat = list(1, "leaders", 1, "displayValue"),
-        points_leader_name = list(1, "leaders", 1, "athlete", "displayName"),
-        points_leader_shortname = list(1, "leaders", 1, "athlete", "shortName"),
-        points_leader_headshot = list(1, "leaders", 1, "athlete", "headshot"),
-        points_leader_team_id = list(1, "leaders", 1, "team", "id"),
-        points_leader_pos = list(1, "leaders", 1, "athlete", "position", "abbreviation"),
-        # rebounds
-        rebounds_leader_rebounds = list(2, "leaders", 1, "value"),
-        rebounds_leader_stat = list(2, "leaders", 1, "displayValue"),
-        rebounds_leader_name = list(2, "leaders", 1, "athlete", "displayName"),
-        rebounds_leader_shortname = list(2, "leaders", 1, "athlete", "shortName"),
-        rebounds_leader_headshot = list(2, "leaders", 1, "athlete", "headshot"),
-        rebounds_leader_team_id = list(2, "leaders", 1, "team", "id"),
-        rebounds_leader_pos = list(2, "leaders", 1, "athlete", "position", "abbreviation"),
-        # assists
-        assists_leader_assists = list(3, "leaders", 1, "value"),
-        assists_leader_stat = list(3, "leaders", 1, "displayValue"),
-        assists_leader_name = list(3, "leaders", 1, "athlete", "displayName"),
-        assists_leader_shortname = list(3, "leaders", 1, "athlete", "shortName"),
-        assists_leader_headshot = list(3, "leaders", 1, "athlete", "headshot"),
-        assists_leader_team_id = list(3, "leaders", 1, "team", "id"),
-        assists_leader_pos = list(3, "leaders", 1, "athlete", "position", "abbreviation"),
-      )
+  tryCatch(
+    expr = {
+      raw_sched <- res %>%
+        httr::content(as = "text", encoding = "UTF-8") %>%
+        jsonlite::fromJSON(simplifyDataFrame = FALSE, simplifyVector = FALSE, simplifyMatrix = FALSE)
 
-    if("broadcasts" %in% names(schedule_out)) {
-      schedule_out %>%
+
+      mbb_data <- raw_sched[["events"]] %>%
+        tibble::tibble(data = .data$.) %>%
+        tidyr::unnest_wider(.data$data) %>%
+        tidyr::unchop(.data$competitions) %>%
+        dplyr::select(-.data$id, -.data$uid, -.data$date, -.data$status) %>%
+        tidyr::unnest_wider(.data$competitions) %>%
+        dplyr::rename(matchup = .data$name, matchup_short = .data$shortName, game_id = .data$id, game_uid = .data$uid, game_date = .data$date) %>%
+        tidyr::hoist(.data$status,
+                     status_name = list("type", "name")) %>%
+        dplyr::select(!dplyr::any_of(c("timeValid", "neutralSite", "conferenceCompetition","recent", "venue", "type"))) %>%
+        tidyr::unnest_wider(.data$season) %>%
+        dplyr::rename(season = .data$year) %>%
+        dplyr::select(-dplyr::any_of("status")) %>%
         tidyr::hoist(
-          .data$broadcasts,
-          broadcast_market = list(1, "market"),
-          broadcast_name = list(1, "names", 1)
+          .data$competitors,
+          home_team_name = list(1, "team", "name"),
+          home_team_logo = list(1, "team", "logo"),
+          home_team_abb = list(1, "team", "abbreviation"),
+          home_team_id = list(1, "team", "id"),
+          home_team_location = list(1, "team", "location"),
+          home_team_full = list(1, "team", "displayName"),
+          home_team_color = list(1, "team", "color"),
+          home_score = list(1, "score"),
+          home_win = list(1, "winner"),
+          home_record = list(1, "records", 1, "summary"),
+          # away team
+          away_team_name = list(2, "team", "name"),
+          away_team_logo = list(2, "team", "logo"),
+          away_team_abb = list(2, "team", "abbreviation"),
+          away_team_id = list(2, "team", "id"),
+          away_team_location = list(2, "team", "location"),
+          away_team_full = list(2, "team", "displayName"),
+          away_team_color = list(2, "team", "color"),
+          away_score = list(2, "score"),
+          away_win = list(2, "winner"),
+          away_record = list(2, "records", 1, "summary"),
         ) %>%
-        dplyr::select(!where(is.list)) %>%
-        janitor::clean_names()
-    } else {
-      schedule_out %>%
-        janitor::clean_names()
+        dplyr::mutate(home_win = as.integer(.data$home_win),
+                      away_win = as.integer(.data$away_win),
+                      home_score = as.integer(.data$home_score),
+                      away_score = as.integer(.data$away_score))
+
+      if("leaders" %in% names(mbb_data)){
+        schedule_out <- mbb_data %>%
+          tidyr::hoist(
+            .data$leaders,
+            # points
+            points_leader_points = list(1, "leaders", 1, "value"),
+            points_leader_stat = list(1, "leaders", 1, "displayValue"),
+            points_leader_name = list(1, "leaders", 1, "athlete", "displayName"),
+            points_leader_shortname = list(1, "leaders", 1, "athlete", "shortName"),
+            points_leader_headshot = list(1, "leaders", 1, "athlete", "headshot"),
+            points_leader_team_id = list(1, "leaders", 1, "team", "id"),
+            points_leader_pos = list(1, "leaders", 1, "athlete", "position", "abbreviation"),
+            # rebounds
+            rebounds_leader_rebounds = list(2, "leaders", 1, "value"),
+            rebounds_leader_stat = list(2, "leaders", 1, "displayValue"),
+            rebounds_leader_name = list(2, "leaders", 1, "athlete", "displayName"),
+            rebounds_leader_shortname = list(2, "leaders", 1, "athlete", "shortName"),
+            rebounds_leader_headshot = list(2, "leaders", 1, "athlete", "headshot"),
+            rebounds_leader_team_id = list(2, "leaders", 1, "team", "id"),
+            rebounds_leader_pos = list(2, "leaders", 1, "athlete", "position", "abbreviation"),
+            # assists
+            assists_leader_assists = list(3, "leaders", 1, "value"),
+            assists_leader_stat = list(3, "leaders", 1, "displayValue"),
+            assists_leader_name = list(3, "leaders", 1, "athlete", "displayName"),
+            assists_leader_shortname = list(3, "leaders", 1, "athlete", "shortName"),
+            assists_leader_headshot = list(3, "leaders", 1, "athlete", "headshot"),
+            assists_leader_team_id = list(3, "leaders", 1, "team", "id"),
+            assists_leader_pos = list(3, "leaders", 1, "athlete", "position", "abbreviation"),
+          )
+
+        if("broadcasts" %in% names(schedule_out)) {
+          schedule_out %>%
+            tidyr::hoist(
+              .data$broadcasts,
+              broadcast_market = list(1, "market"),
+              broadcast_name = list(1, "names", 1)
+            ) %>%
+            dplyr::select(!where(is.list)) %>%
+            janitor::clean_names()
+        } else {
+          schedule_out %>%
+            janitor::clean_names()
+        }
+      } else {
+        mbb_data %>% dplyr::select(!where(is.list)) %>%
+          janitor::clean_names()
+      }
+
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no scoreboard data for {game_id} available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
     }
-  } else {
-    cbb_data %>% dplyr::select(!where(is.list)) %>%
-      janitor::clean_names()
-  }
-
+  )
 }
-
-#' @import utils
-utils::globalVariables(c("where"))
 
 #' Get men's college basketball NET rankings for the current date from the NCAA website
 #'
@@ -508,33 +668,49 @@ espn_mbb_rankings <- function(){
 
   ranks_url <- "http://site.api.espn.com/apis/site/v2/sports/basketball/mens-college-basketball/rankings?groups=50"
 
-  ## Inputs
-  ## game_id
+  res <- httr::RETRY("GET", ranks_url)
 
+  # Check the result
+  check_status(res)
 
-  ranks_df <- jsonlite::fromJSON(ranks_url,flatten = TRUE)[['rankings']]
-  ranks_top25 <- ranks_df %>%
-    tidyr::unnest(.data$ranks, names_repair="minimal") %>%
-    dplyr::select(-.data$date,-.data$lastUpdated)
-  ranks_others <- ranks_df %>%
-    tidyr::unnest(.data$others, names_repair="minimal") %>%
-    dplyr::select(-.data$date,-.data$lastUpdated)
-  ranks_dropped_out <- ranks_df %>%
-    tidyr::unnest(.data$droppedOut, names_repair="minimal") %>%
-    dplyr::select(-.data$date,-.data$lastUpdated)
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
 
-  ranks <- dplyr::bind_rows(ranks_top25, ranks_others, ranks_dropped_out)
-  drop_cols <- c(
-    "$ref", "team.links","season.powerIndexes.$ref",
-    "season.powerIndexLeaders.$ref", "season.athletes.$ref",
-    "season.leaders.$ref","season.powerIndexLeaders.$ref",
-    "others","droppedOut","ranks"
+  tryCatch(
+    expr = {
+      ranks_df <- jsonlite::fromJSON(resp,flatten = TRUE)[['rankings']]
+      ranks_top25 <- ranks_df %>%
+        tidyr::unnest(.data$ranks, names_repair="minimal") %>%
+        dplyr::select(-.data$date,-.data$lastUpdated)
+      ranks_others <- ranks_df %>%
+        tidyr::unnest(.data$others, names_repair="minimal") %>%
+        dplyr::select(-.data$date,-.data$lastUpdated)
+      ranks_dropped_out <- ranks_df %>%
+        tidyr::unnest(.data$droppedOut, names_repair="minimal") %>%
+        dplyr::select(-.data$date,-.data$lastUpdated)
+
+      ranks <- dplyr::bind_rows(ranks_top25, ranks_others, ranks_dropped_out)
+      drop_cols <- c(
+        "$ref", "team.links","season.powerIndexes.$ref",
+        "season.powerIndexLeaders.$ref", "season.athletes.$ref",
+        "season.leaders.$ref","season.powerIndexLeaders.$ref",
+        "others","droppedOut","ranks"
+      )
+      ranks <- ranks  %>%
+        dplyr::select(-dplyr::any_of(drop_cols))
+      ranks <- ranks %>% dplyr::arrange(.data$name,-.data$points) %>%
+        janitor::clean_names() %>%
+        janitor::clean_names()
+    },
+    error = function(e) {
+      message(glue::glue("{Sys.time()}: Invalid arguments or no rankings data for {game_id} available!"))
+    },
+    warning = function(w) {
+    },
+    finally = {
+    }
   )
-  ranks <- ranks  %>%
-    dplyr::select(-dplyr::any_of(drop_cols))
-  ranks <- ranks %>% dplyr::arrange(.data$name,-.data$points) %>%
-    janitor::clean_names() %>%
-    janitor::clean_names()
+
   return(ranks)
 }
 

--- a/R/espn_nba_data.R
+++ b/R/espn_nba_data.R
@@ -23,7 +23,18 @@ espn_nba_game_all <- function(game_id){
   ## game_id
   full_url <- paste0(play_base_url,
                      "gameId=", game_id)
-  raw_play_df <- jsonlite::fromJSON(full_url)[["gamepackageJSON"]]
+
+  res <- httr::RETRY("GET", full_url)
+
+  # Check the result
+  check_status(res)
+
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
   raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
 
   #---- Play-by-Play ------
@@ -38,6 +49,19 @@ espn_nba_game_all <- function(game_id){
   names(aths)<-c("play.id","athlete1.id","athlete2.id","athlete3.id")
   plays_df <- dplyr::bind_cols(plays, aths) %>%
     select(-.data$athlete.id)
+    },
+  error = function(e) {
+    message(glue::glue("{Sys.time()}: Invalid arguments or no play-by-play data for {game_id} available!"))
+  },
+  warning = function(w) {
+  },
+  finally = {
+  }
+  )
+  #---- Team Box ------
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
   #---- Team Box ------
   teams_box_score_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["teams"]]),flatten=TRUE)
   teams_box_score_df_2 <- teams_box_score_df[[1]][[2]] %>%
@@ -51,7 +75,19 @@ espn_nba_game_all <- function(game_id){
   tm <- c(teams_box_score_df[2,"team.shortDisplayName"], "Team", teams_box_score_df[1,"team.shortDisplayName"])
   names(tm) <- c("Home","label","Away")
   team_box_score = dplyr::bind_rows(tm, team_box_score)
+    },
+  error = function(e) {
+    message(glue::glue("{Sys.time()}: Invalid arguments or no team box score data for {game_id} available!"))
+  },
+  warning = function(w) {
+  },
+  finally = {
+  }
+  )
   #---- Player Box ------
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
   players_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["players"]]), flatten=TRUE) %>%
     tidyr::unnest(.data$statistics) %>%
     tidyr::unnest(.data$athletes)
@@ -84,6 +120,15 @@ espn_nba_game_all <- function(game_id){
       '+/-'=.data$x,
       fg3 = .data$x3pt
     )
+  },
+  error = function(e) {
+    message(glue::glue("{Sys.time()}: Invalid arguments or no player box score data for {game_id} available!"))
+  },
+  warning = function(w) {
+  },
+  finally = {
+  }
+  )
   pbp <- c(list(plays_df), list(team_box_score),list(player_box))
   names(pbp) <- c("Plays","Team","Player")
   return(pbp)
@@ -113,7 +158,18 @@ espn_nba_pbp <- function(game_id){
   ## game_id
   full_url <- paste0(play_base_url,
                      "gameId=", game_id)
-  raw_play_df <- jsonlite::fromJSON(full_url)[["gamepackageJSON"]]
+
+
+  res <- httr::RETRY("GET", full_url)
+
+  # Check the result
+  check_status(res)
+
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
   raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
   #---- Play-by-Play ------
   plays <- raw_play_df[["plays"]] %>%
@@ -130,6 +186,16 @@ espn_nba_pbp <- function(game_id){
 
   plays_df <- plays_df %>%
     janitor::clean_names()
+    },
+  error = function(e) {
+    message(glue::glue("{Sys.time()}: Invalid arguments or no play-by-play data for {game_id} available!"))
+  },
+  warning = function(w) {
+  },
+  finally = {
+  }
+  )
+
 
   return(plays_df)
 }
@@ -156,7 +222,19 @@ espn_nba_team_box <- function(game_id){
   ## game_id
   full_url <- paste0(play_base_url,
                      "gameId=", game_id)
-  raw_play_df <- jsonlite::fromJSON(full_url)[["gamepackageJSON"]]
+
+  res <- httr::RETRY("GET", full_url)
+
+  # Check the result
+  check_status(res)
+
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+
+  #---- Team Box ------
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
   raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
   #---- Team Box ------
   teams_box_score_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["teams"]]),flatten=TRUE)
@@ -173,7 +251,15 @@ espn_nba_team_box <- function(game_id){
   team_box_score = dplyr::bind_rows(tm, team_box_score)
   team_box_score <- team_box_score %>%
     janitor::clean_names()
-
+    },
+  error = function(e) {
+    message(glue::glue("{Sys.time()}: Invalid arguments or no team box score data for {game_id} available!"))
+  },
+  warning = function(w) {
+  },
+  finally = {
+  }
+  )
   return(team_box_score)
 }
 #' Get ESPN NBA player box scores
@@ -199,7 +285,19 @@ espn_nba_player_box <- function(game_id){
   ## game_id
   full_url <- paste0(play_base_url,
                      "gameId=", game_id)
-  raw_play_df <- jsonlite::fromJSON(full_url)[["gamepackageJSON"]]
+
+  res <- httr::RETRY("GET", full_url)
+
+  # Check the result
+  check_status(res)
+
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+
+  #---- Player Box ------
+  tryCatch(
+    expr = {
+      raw_play_df <- jsonlite::fromJSON(resp)[["gamepackageJSON"]]
   raw_play_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df),flatten=TRUE)
   #---- Player Box ------
   players_df <- jsonlite::fromJSON(jsonlite::toJSON(raw_play_df[["boxscore"]][["players"]]), flatten=TRUE) %>%
@@ -230,6 +328,15 @@ espn_nba_player_box <- function(game_id){
       '+/-'=.data$x,
       fg3 = .data$x3pt
     )
+    },
+  error = function(e) {
+    message(glue::glue("{Sys.time()}: Invalid arguments or no player box score data for {game_id} available!"))
+  },
+  warning = function(w) {
+  },
+  finally = {
+  }
+  )
   return(player_box)
 }
 
@@ -254,9 +361,19 @@ espn_nba_teams <- function(){
   options(scipen = 999)
   play_base_url <- "http://site.api.espn.com/apis/site/v2/sports/basketball/nba/teams?limit=1000"
 
-  ## Inputs
-  ## game_id
-  leagues <- jsonlite::fromJSON(play_base_url)[["sports"]][["leagues"]][[1]][['teams']][[1]][['team']] %>%
+
+  res <- httr::RETRY("GET", play_base_url)
+
+  # Check the result
+  check_status(res)
+
+  resp <- res %>%
+    httr::content(as = "text", encoding = "UTF-8")
+
+  tryCatch(
+    expr = {
+
+      leagues <- jsonlite::fromJSON(resp)[["sports"]][["leagues"]][[1]][['teams']][[1]][['team']] %>%
     dplyr::group_by(.data$id) %>%
     tidyr::unnest_wider(unlist(.data$logos, use.names=FALSE),names_sep = "_") %>%
     tidyr::unnest_wider(.data$logos_href,names_sep = "_") %>%
@@ -304,6 +421,15 @@ espn_nba_teams <- function(){
       display_name = .data$displayName
     ) %>%
     janitor::clean_names()
+    },
+  error = function(e) {
+    message(glue::glue("{Sys.time()}: Invalid arguments or no teams data available!"))
+  },
+  warning = function(w) {
+  },
+  finally = {
+  }
+  )
   return(teams)
 }
 
@@ -342,7 +468,16 @@ espn_nba_scoreboard <- function(season){
 
   schedule_api <- glue::glue("http://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard?limit=1000&dates={season_dates}")
 
-  raw_sched <- jsonlite::fromJSON(schedule_api, simplifyDataFrame = FALSE, simplifyVector = FALSE, simplifyMatrix = FALSE)
+  res <- httr::RETRY("GET", schedule_api)
+
+  # Check the result
+  check_status(res)
+
+  tryCatch(
+    expr = {
+      raw_sched <- res %>%
+        httr::content(as = "text", encoding = "UTF-8") %>%
+        jsonlite::fromJSON(simplifyDataFrame = FALSE, simplifyVector = FALSE, simplifyMatrix = FALSE)
 
   nba_data <- raw_sched[["events"]] %>%
     tibble::tibble(data = .data$.) %>%
@@ -433,7 +568,16 @@ espn_nba_scoreboard <- function(season){
     nba_data %>% dplyr::select(!where(is.list)) %>%
       janitor::clean_names()
   }
-
+    },
+  error = function(e) {
+    message(glue::glue("{Sys.time()}: Invalid arguments or no scoreboard data for {game_id} available!"))
+  },
+  warning = function(w) {
+  },
+  finally = {
+  }
+  )
 }
+
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -206,3 +206,8 @@ check_status <- function(res) {
   if(x != 200) stop("The API returned an error", call. = FALSE)
 
 }
+
+
+#' @import utils
+utils::globalVariables(c("where"))
+

--- a/README.Rmd
+++ b/README.Rmd
@@ -128,17 +128,18 @@ For more information on the package and function reference, please see the  [**`
 
 [**Full News on Releases**](https://saiemgilani.github.io/hoopR/news/index.html)
 
-# **hoopR 1.0.2** 
+# **hoopR 1.0.4**
+### **Add retry**
+- Adding [```httr::retry()```](https://httr.r-lib.org/reference/RETRY.html) to all function calls to more naturally navigate rejected/failed requests from the API.
 
-### Quick fix for update db functions
+# **hoopR 1.0.2-3** 
+### **Quick fix for update db functions**
 
 # **hoopR 1.0.1**
-
 ### **Dependency pruning**
 This update is a non-user facing change to package dependencies to shrink the list of dependencies.
 
 # **hoopR 1.0.0**
-
 ### **Package renamed to hoopR**
 To reflect that the package is no longer just a men's college basketball and KenPom package, but also an NBA package. 
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,12 @@ website](https://saiemgilani.github.io/hoopR/).
 [**Full News on
 Releases**](https://saiemgilani.github.io/hoopR/news/index.html)
 
-# **hoopR 1.0.2**
+# **hoopR 1.0.4**
+
+  - Adding \[httr::retry()\] to all function calls to more naturally
+    navigate rejected/failed requests from the API.
+
+# **hoopR 1.0.2-3**
 
 ### Quick fix for update db functions
 
@@ -230,7 +235,7 @@ See the following ~~four~~ eight functions:
 
 | issue | icon                                                                                                                                         | title                                                                                                                                                       | labels | opened\_by                                      | date       | closed              |
 | :---- | :------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------- | :----- | :---------------------------------------------- | :--------- | :------------------ |
-| 14    | <span title="Closed Issue"><img src="https://github.com/yonicd/issue/blob/master/inst/icons/issue-closed.png?raw=true"></span>               | <span title="    library(hoopR)...">[Error in “update\_nba\_db”: could not find function “my\_time”](https://github.com/saiemgilani/hoopR/issues/14)</span> |        | [jedwards757](https://github.com/jedwards757)   | 2021-05-20 | 2021-05-20 19:32:19 |
+| 14    | <span title="Closed Issue"><img src="https://github.com/yonicd/issue/blob/master/inst/icons/issue-closed.png?raw=true"></span>               | <span title="    library(hoopR)...">[Error in “update\_nba\_db”: could not find function “my\_time”](https://github.com/saiemgilani/hoopR/issues/14)</span> |        | [jedwards757](https://github.com/jedwards757)   | 2021-05-20 | 2021-05-20 22:53:32 |
 | 1     | <span title="Closed Issue"><img src="https://github.com/yonicd/issue/blob/master/inst/icons/issue-closed.png?raw=true"></span>               | <span title="**Describe the bug**...">[gameplan function error](https://github.com/saiemgilani/hoopR/issues/1)</span>                                       | bug    | [mcoleman9221](https://github.com/mcoleman9221) | 2021-01-28 | 2021-01-28 03:31:48 |
 | 15    | <span title="Merged Pull Request"><img src="https://github.com/yonicd/issue/blob/master/inst/icons/pull-request-merged.png?raw=true"></span> | <span title="closes #14 ">[my\_time](https://github.com/saiemgilani/hoopR/pull/15)</span>                                                                   | bug    | [saiemgilani](https://github.com/saiemgilani)   | 2021-05-20 | 2021-05-20 19:32:20 |
 | 13    | <span title="Merged Pull Request"><img src="https://github.com/yonicd/issue/blob/master/inst/icons/pull-request-merged.png?raw=true"></span> | <span title="Packages moved from `Imports` to `Suggests`:...">[dependency pruning the functions](https://github.com/saiemgilani/hoopR/pull/13)</span>       |        | [saiemgilani](https://github.com/saiemgilani)   | 2021-05-20 | 2021-05-20 13:52:01 |


### PR DESCRIPTION
- Adding [```httr::retry()```](https://httr.r-lib.org/reference/RETRY.html) to all function calls to more naturally navigate rejected/failed requests from the API.