### PR TITLE
schedule loaders

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hoopR
 Title: Functions to Access Men's Basketball Play by Play Data
-Version: 1.1.0
+Version: 1.2.0
 Authors@R: 
     person(given = "Saiem",
            family = "Gilani",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# **hoopR 1.2.0**
+
+### **Add schedule loaders**
+
+  - [`hoopR::load_mbb_schedule()`](https://saiemgilani.github.io/hoopR/reference/load_mbb_schedule.html)
+    function added
+  - [`hoopR::load_nba_schedule()`](https://saiemgilani.github.io/hoopR/reference/load_nba_schedule.html)
+    function added
+
 # **hoopR 1.1.0** 
 ### **Add team box score loaders**
 - [```hoopR::load_mbb_team_box()```](https://saiemgilani.github.io/hoopR/reference/load_mbb_team_box.html) function added

--- a/R/mbb_pbp.R
+++ b/R/mbb_pbp.R
@@ -242,6 +242,85 @@ mbb_player_box_single_season <- function(season, p, dbConnection = NULL, tablena
 }
 
 
+#' **Load hoopR men's college basketball schedule**
+#' @name load_mbb_schedule
+NULL
+#' @title
+#' **Load cleaned men's college basketball schedule from the data repo**
+#' @rdname load_mbb_schedule
+#' @description helper that loads multiple seasons from the data repo either into memory
+#' or writes it into a db using some forwarded arguments in the dots
+#' @param seasons A vector of 4-digit years associated with given men's college basketball seasons.
+#' @param ... Additional arguments passed to an underlying function that writes
+#' the season data into a database (used by \code{\link[=update_mbb_db]{update_mbb_db()}}).
+#' @param qs Wheter to use the function [qs::qdeserialize()] for more efficient loading.
+#' @import furrr
+#' @export
+#' @examples \dontrun{
+#' future::plan("multisession")
+#' load_mbb_schedule(2002:2021)
+#' }
+load_mbb_schedule <- function(seasons, ..., qs = FALSE) {
+  options(stringsAsFactors = FALSE)
+  options(scipen = 999)
+  dots <- rlang::dots_list(...)
+
+  if (all(c("dbConnection", "tablename") %in% names(dots))) in_db <- TRUE else in_db <- FALSE
+
+  if (isTRUE(qs) && !is_installed("qs")) {
+    usethis::ui_stop("Package {usethis::ui_value('qs')} required for argument {usethis::ui_value('qs = TRUE')}. Please install it.")
+  }
+
+  most_recent <- most_recent_mbb_season()
+
+  if (!all(seasons %in% 2002:most_recent)) {
+    usethis::ui_stop("Please pass valid seasons between 2002 and {most_recent}")
+  }
+
+  if (length(seasons) > 1 && is_sequential() && isFALSE(in_db)) {
+    usethis::ui_info(c(
+      "It is recommended to use parallel processing when trying to load multiple seasons.",
+      "Please consider running {usethis::ui_code('future::plan(\"multisession\")')}!",
+      "Will go on sequentially..."
+    ))
+  }
+
+
+  p <- progressr::progressor(along = seasons)
+
+  if (isFALSE(in_db)) {
+    out <- furrr::future_map_dfr(seasons, mbb_schedule_single_season, p = p, qs = qs)
+  }
+
+  if (isTRUE(in_db)) {
+    purrr::walk(seasons, mbb_schedule_single_season, p, ..., qs = qs)
+    out <- NULL
+  }
+
+  return(out)
+}
+
+mbb_schedule_single_season <- function(season, p, dbConnection = NULL, tablename = NULL, qs = FALSE) {
+
+  .url <- glue::glue("https://raw.githubusercontent.com/saiemgilani/hoopR-data/master/mbb/schedules/mbb_schedule_{season}.csv")
+  con <- url(.url)
+  pbp <- utils::read.csv(con)
+  pbp <- pbp %>%
+    dplyr::mutate(
+      status.displayClock = as.character(.data$status.displayClock)
+    )
+
+  if (!is.null(dbConnection) && !is.null(tablename)) {
+    DBI::dbWriteTable(dbConnection, tablename, pbp, append = TRUE)
+    out <- NULL
+  } else {
+    out <- pbp
+  }
+  p(sprintf("season=%g", season))
+  return(out)
+}
+
+
 # load games file
 load_mbb_games <- function(){
   .url <- "https://raw.githubusercontent.com/saiemgilani/hoopR-data/master/mbb/mbb_games_in_data_repo.csv"

--- a/R/nba_pbp.R
+++ b/R/nba_pbp.R
@@ -243,6 +243,86 @@ nba_player_box_single_season <- function(season, p, dbConnection = NULL, tablena
   return(out)
 }
 
+#' **Load hoopR NBA schedules**
+#' @name load_nba_schedule
+NULL
+#' @title
+#' **Load cleaned NBA schedules from the data repo**
+#' @rdname load_nba_schedule
+#' @description helper that loads multiple seasons from the data repo either into memory
+#' or writes it into a db using some forwarded arguments in the dots
+#' @param seasons A vector of 4-digit years associated with given NBA seasons.
+#' @param ... Additional arguments passed to an underlying function that writes
+#' the season data into a database (used by \code{\link[=update_nba_db]{update_nba_db()}}).
+#' @param qs Wheter to use the function [qs::qdeserialize()] for more efficient loading.
+#' @import furrr
+#' @export
+#' @examples
+#' \dontrun{
+#' future::plan("multisession")
+#' load_nba_schedule(2002:2021)
+#' }
+load_nba_schedule <- function(seasons, ..., qs = FALSE) {
+  options(stringsAsFactors = FALSE)
+  options(scipen = 999)
+  dots <- rlang::dots_list(...)
+
+  if (all(c("dbConnection", "tablename") %in% names(dots))) in_db <- TRUE else in_db <- FALSE
+
+  if (isTRUE(qs) && !is_installed("qs")) {
+    usethis::ui_stop("Package {usethis::ui_value('qs')} required for argument {usethis::ui_value('qs = TRUE')}. Please install it.")
+  }
+
+  most_recent <- most_recent_nba_season()
+
+  if (!all(seasons %in% 2002:most_recent)) {
+    usethis::ui_stop("Please pass valid seasons between 2002 and {most_recent}")
+  }
+
+  if (length(seasons) > 1 && is_sequential() && isFALSE(in_db)) {
+    usethis::ui_info(c(
+      "It is recommended to use parallel processing when trying to load multiple seasons.",
+      "Please consider running {usethis::ui_code('future::plan(\"multisession\")')}!",
+      "Will go on sequentially..."
+    ))
+  }
+
+
+  p <- progressr::progressor(along = seasons)
+
+  if (isFALSE(in_db)) {
+    out <- furrr::future_map_dfr(seasons, nba_schedule_single_season, p = p, qs = qs)
+  }
+
+  if (isTRUE(in_db)) {
+    purrr::walk(seasons, nba_schedule_single_season, p, ..., qs = qs)
+    out <- NULL
+  }
+
+  return(out)
+}
+
+nba_schedule_single_season <- function(season, p, dbConnection = NULL, tablename = NULL, qs = FALSE) {
+
+
+  .url <- glue::glue("https://raw.githubusercontent.com/saiemgilani/hoopR-data/master/nba/schedules/nba_schedule_{season}.csv")
+  con <- url(.url)
+  pbp <- utils::read.csv(con)
+  pbp <- pbp %>%
+    dplyr::mutate(
+      status.displayClock = as.character(.data$status.displayClock)
+    )
+  if (!is.null(dbConnection) && !is.null(tablename)) {
+    DBI::dbWriteTable(dbConnection, tablename, pbp, append = TRUE)
+    out <- NULL
+  } else {
+    out <- pbp
+  }
+  p(sprintf("season=%g", season))
+  return(out)
+}
+
+
 # load games file
 load_nba_games <- function(){
   .url <- "https://raw.githubusercontent.com/saiemgilani/hoopR-data/master/nba/nba_games_in_data_repo.csv"

--- a/README.Rmd
+++ b/README.Rmd
@@ -128,7 +128,19 @@ For more information on the package and function reference, please see the  [**`
 
 [**Full News on Releases**](https://saiemgilani.github.io/hoopR/news/index.html)
 
-# **hoopR 1.1.0** 
+
+# **hoopR 1.2.0**
+
+### **Add schedule loaders**
+
+  - [`hoopR::load_mbb_schedule()`](https://saiemgilani.github.io/hoopR/reference/load_mbb_schedule.html) function added
+  - [`hoopR::load_nba_schedule()`](https://saiemgilani.github.io/hoopR/reference/load_nba_schedule.html) function added
+
+#
+<details>
+<summary>View more version news</summary>
+    
+## **hoopR 1.1.0** 
 ### **Add team box score loaders**
 - [```hoopR::load_mbb_team_box()```](https://saiemgilani.github.io/hoopR/reference/load_mbb_team_box.html) function added
 - [```hoopR::load_nba_team_box()```](https://saiemgilani.github.io/hoopR/reference/load_nba_team_box.html) function added
@@ -136,10 +148,6 @@ For more information on the package and function reference, please see the  [**`
 ### **Add player box score loaders**
 - [```hoopR::load_mbb_player_box()```](https://saiemgilani.github.io/hoopR/reference/load_mbb_player_box.html) function added
 - [```hoopR::load_nba_player_box()```](https://saiemgilani.github.io/hoopR/reference/load_nba_player_box.html) function added
-
-#
-<details>
-<summary>View more version news</summary>
 
 ## **hoopR 1.0.5**
 ### **Standings functions**

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -92,6 +92,7 @@ reference:
       - '`load_nba_pbp`'
       - '`load_nba_team_box`'
       - '`load_nba_player_box`'
+      - '`load_nba_schedule`'
       - '`update_nba_db`'
   - subtitle: Men's College Basketball Data Functions
     desc: Functions exported by hoopR to access the hoopR-data repository's Men's College Basketball Data
@@ -99,6 +100,7 @@ reference:
       - '`load_mbb_pbp`'
       - '`load_mbb_team_box`'
       - '`load_mbb_player_box`'
+      - '`load_mbb_schedule`'
       - '`update_mbb_db`'
   - title: ESPN Data
   - subtitle: Men's College Basketball Data Functions


### PR DESCRIPTION
# **hoopR 1.2.0**

### **Add schedule loaders**

  - [`hoopR::load_mbb_schedule()`](https://saiemgilani.github.io/hoopR/reference/load_mbb_schedule.html) function added
  - [`hoopR::load_nba_schedule()`](https://saiemgilani.github.io/hoopR/reference/load_nba_schedule.html) function added